### PR TITLE
Update boringssl and armv7 support

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -15,8 +15,6 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -34,6 +32,6 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          platforms: linux/amd64,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
           push: true
           tags: quay.io/invidious/lsquic-compiled:${{ github.sha }},quay.io/invidious/lsquic-compiled:latest

--- a/docker/APKBUILD-boringssl
+++ b/docker/APKBUILD-boringssl
@@ -12,8 +12,8 @@ depends="!openssl-libs-static"
 makedepends_host="linux-headers"
 makedepends="cmake git go perl"
 subpackages="$pkgname-static $pkgname-dev $pkgname-doc"
-source="251b516.tar.gz::https://github.com/google/boringssl/tarball/251b516"
-builddir="$srcdir/google-boringssl-251b516"
+source="c239ffd.tar.gz::https://github.com/google/boringssl/tarball/c239ffd"
+builddir="$srcdir/google-boringssl-c239ffd"
 
 prepare() {
 	:
@@ -41,6 +41,4 @@ package() {
 #	install -Dm755 decrepit/libdecrepit.a "$pkgdir/usr/lib/libdecrepit.a"
 #	install -Dm755 libboringssl_gtest.a "$pkgdir/usr/lib/libboringssl_gtest.a"
 }
-sha512sums="
-b1d42ed188cf0cce89d40061fa05de85b387ee4244f1236ea488a431536a2c6b657b4f03daed0ac9328c7f5c4c9330499283b8a67f1444dcf9ba5e97e1199c4e  251b516.tar.gz
-"
+sha512sums="fad2e914fdefeaa4ef0add297a214cbecac9f1290f8a3aa63df97890ab7d4cb569183a140b6d9216c719a857c163705df7f1721e956a9b0355117a5eef58d469  c239ffd.tar.gz"


### PR DESCRIPTION
Updated boringssl as the current version was failing to build with newer GCC versions in alpine. See this [issue](https://github.com/google/mundane/issues/32).

Also add armv7 support to the docker build to support 32 bit Raspberry Pi OS installs.